### PR TITLE
chore(codeowners): rename platform to devex-sre

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @articulate/platform
+* @articulate/devex-sre


### PR DESCRIPTION
<img src="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExbTVuaWxxOG5rNHMwYndhYjM1ZWJuc3BkZWhodXRvZGFoN3dwa3JjbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SdEOWdAYbyD0jExUgd/giphy.gif" alt="people can change" width="300px"/>

Changes are a part of The Great Renaming— the `platform` group name has been renamed to `devex-sre`, so any repos referencing this need to be updated.