### PR TITLE
feat: add dumb-init as entrypoint

### DIFF
--- a/bookworm/base/Dockerfile
+++ b/bookworm/base/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETARCH
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/install_packages /usr/local/bin/install_packages
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/awscli.sh /tmp/awscli.sh
 
-RUN install_packages make && /tmp/awscli.sh && rm /tmp/awscli.sh \
+RUN install_packages make dumb-init && /tmp/awscli.sh && rm /tmp/awscli.sh \
     && groupadd --gid $SERVICE_UID $SERVICE_USER \
     && useradd --create-home --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER
 
@@ -25,4 +25,4 @@ WORKDIR $SERVICE_ROOT
 # Our entrypoint will pull in our environment variables from Consul and Vault,
 # and execute whatever command we provided the container.
 # See https://github.com/articulate/docker-bootstrap
-ENTRYPOINT [ "/entrypoint" ]
+ENTRYPOINT [ "dumb-init", "--", "/entrypoint" ]


### PR DESCRIPTION
Use dumb-init to handle zombie processes and forwarding signals.