### PR TITLE
feat(tls): Add AWS RDS CA certificates to debian images

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Base Debian Docker images.
   to install apt packages.
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
   for interacting with AWS services.
+* [AWS RDS CA Certificates](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html)
+  to enable trusted TLS connections with AWS RDS instances _(in any region)_.
 
 ## Tags
 

--- a/bookworm/base/Dockerfile
+++ b/bookworm/base/Dockerfile
@@ -8,10 +8,18 @@ ARG TARGETARCH
 
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/install_packages /usr/local/bin/install_packages
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/awscli.sh /tmp/awscli.sh
+# Add AWS RDS CA trusted root certificates
+ADD --chmod=644 https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.pem
 
-RUN install_packages make dumb-init && /tmp/awscli.sh && rm /tmp/awscli.sh \
+RUN install_packages make dumb-init ca-certificates && /tmp/awscli.sh && rm /tmp/awscli.sh \
     && groupadd --gid $SERVICE_UID $SERVICE_USER \
-    && useradd --create-home --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER
+    && useradd --create-home --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER \
+    # Split PEM bundle into individual cert files for update-ca-certificates
+    && csplit -s -z -n 3 -f /usr/local/share/ca-certificates/aws-rds-ca- \
+      /usr/local/share/ca-certificates/aws-rds-global-bundle.pem  \
+      '/-----BEGIN CERTIFICATE-----/' '{*}' \
+    && for f in /usr/local/share/ca-certificates/aws-rds-ca-*; do mv "$f" "$f.crt"; done \
+    && update-ca-certificates
 
 ADD --chmod=755 https://github.com/articulate/docker-bootstrap/releases/latest/download/docker-bootstrap_linux_${TARGETARCH} /entrypoint
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets


### PR DESCRIPTION
Add [AWS RDS CA certificates](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) to enable trusted TLS connections with RDS in any region.
- Adds the certs to the OS trust store with `update-ca-certificates`.
- _Related to Slack conversations [here](https://articulate.slack.com/archives/CKFUF179T/p1766160735025729) and [here](https://articulate.slack.com/archives/C2QFA5938/p1767067851722719?thread_ts=1767040162.264079&cid=C2QFA5938), caused by attempts to upgrade to PostgreSQL 17._

Related to https://github.com/articulate/infosec/issues/348
